### PR TITLE
Update LS-BUS demos and extend bus simulation

### DIFF
--- a/ls-bus-guide/demos/can-bus-simulation/PackFmu.py
+++ b/ls-bus-guide/demos/can-bus-simulation/PackFmu.py
@@ -9,7 +9,7 @@ FMU_PATH = Path('DemoCanBusSimulation.fmu')
 
 # Repository to fetch the LS-BUS headers from
 LS_BUS_REPO = 'modelica/fmi-ls-bus'
-LS_BUS_REV = '4680d63c0705fbf9076f97128e913f464b442f53'
+LS_BUS_REV = '7d277c5d55b294f69d61627b1968f39d7ff9fc4d'
 LS_BUS_HEADERS = [ 'fmi3LsBus.h', 'fmi3LsBusCan.h', 'fmi3LsBusUtil.h', 'fmi3LsBusUtilCan.h' ]
 
 

--- a/ls-bus-guide/demos/can-bus-simulation/README.md
+++ b/ls-bus-guide/demos/can-bus-simulation/README.md
@@ -6,7 +6,8 @@ The FMU provides terminals to connect exactly two nodes.
 Currently, the bus simulation provides the following capabilities:
 - Forwarding of CAN frames and sending confirmations
 - Basic timing simulation based on baud rate
-- Basic frame priorization
+- Basic simulation of arbitration
+- Basic error injection
 
 The FMU requires a simulator with support for triggered and countdown clocks, event mode and variable step size.
 
@@ -26,3 +27,6 @@ This FMU can then be loaded by an importer or precompiled using, e.g., FMPy.
 
 To run the FMU, a supported simulator and two CAN node FMUs (e.g., from the demo `can-node-triggered-output`) are required.
 The node FMUs must be connected to the `Node1` and `Node2` terminals.
+
+To simulate bus errors, you can configure the variable `BusErrorProbability` to specify a probability of an error
+being simulated by the bus simulation FMU for a single frame. You can specify value between 0.0 and 1.0.

--- a/ls-bus-guide/demos/can-bus-simulation/description/modelDescription.xml
+++ b/ls-bus-guide/demos/can-bus-simulation/description/modelDescription.xml
@@ -43,7 +43,7 @@
   <ModelVariables>
     <Float64 name="time" valueReference="1024" causality="independent" variability="continuous" description="Simulation time" />
 
-    <Binary name="Node1::Rx_Data"
+    <Binary name="Node1.Rx_Data"
         valueReference="0"
         causality="input"
         variability="discrete"
@@ -55,7 +55,7 @@
         <Start value="" />
     </Binary>
 
-    <Binary name="Node1::Tx_Data"
+    <Binary name="Node1.Tx_Data"
         valueReference="1"
         causality="output"
         variability="discrete"
@@ -65,10 +65,10 @@
         mimeType="org.fmi-standard.fmi-ls-bus.v1.can">
     </Binary>
 
-    <Clock name="Node1::Rx_Clock" valueReference="2" causality="input" intervalVariability="triggered" />
-    <Clock name="Node1::Tx_Clock" valueReference="3" causality="input" intervalVariability="countdown" />
+    <Clock name="Node1.Rx_Clock" valueReference="2" causality="input" intervalVariability="triggered" />
+    <Clock name="Node1.Tx_Clock" valueReference="3" causality="input" intervalVariability="countdown" />
 
-    <Binary name="Node2::Rx_Data"
+    <Binary name="Node2.Rx_Data"
             valueReference="4"
             causality="input"
             variability="discrete"
@@ -80,7 +80,7 @@
       <Start value="" />
     </Binary>
 
-    <Binary name="Node2::Tx_Data"
+    <Binary name="Node2.Tx_Data"
             valueReference="5"
             causality="output"
             variability="discrete"
@@ -90,8 +90,10 @@
             mimeType="org.fmi-standard.fmi-ls-bus.v1.can">
     </Binary>
 
-    <Clock name="Node2::Rx_Clock" valueReference="6" causality="input" intervalVariability="triggered" />
-    <Clock name="Node2::Tx_Clock" valueReference="7" causality="input" intervalVariability="countdown" />
+    <Clock name="Node2.Rx_Clock" valueReference="6" causality="input" intervalVariability="triggered" />
+    <Clock name="Node2.Tx_Clock" valueReference="7" causality="input" intervalVariability="countdown" />
+    
+    <Float64 name="BusErrorProbability" valueReference="255" causality="input" variability="discrete" start="0.0" />
   </ModelVariables>
 
   <ModelStructure>

--- a/ls-bus-guide/demos/can-bus-simulation/description/terminalsAndIcons.xml
+++ b/ls-bus-guide/demos/can-bus-simulation/description/terminalsAndIcons.xml
@@ -8,16 +8,16 @@
               name="Node1"
               description="CAN bus terminal definition">
       <TerminalMemberVariable variableKind="signal"
-                              variableName="Node1::Rx_Clock"
+                              variableName="Node1.Rx_Clock"
                               memberName="Rx_Clock" />
       <TerminalMemberVariable variableKind="signal"
-                              variableName="Node1::Rx_Data"
+                              variableName="Node1.Rx_Data"
                               memberName="Rx_Data" />
       <TerminalMemberVariable variableKind="signal"
-                              variableName="Node1::Tx_Clock"
+                              variableName="Node1.Tx_Clock"
                               memberName="Tx_Clock" />
       <TerminalMemberVariable variableKind="signal"
-                              variableName="Node1::Tx_Data"
+                              variableName="Node1.Tx_Data"
                               memberName="Tx_Data" />
     </Terminal>
     <Terminal terminalKind="org.fmi-ls-bus.network-terminal"
@@ -25,16 +25,16 @@
               name="Node2"
               description="CAN bus terminal definition">
       <TerminalMemberVariable variableKind="signal"
-                              variableName="Node2::Rx_Clock"
+                              variableName="Node2.Rx_Clock"
                               memberName="Rx_Clock" />
       <TerminalMemberVariable variableKind="signal"
-                              variableName="Node2::Rx_Data"
+                              variableName="Node2.Rx_Data"
                               memberName="Rx_Data" />
       <TerminalMemberVariable variableKind="signal"
-                              variableName="Node2::Tx_Clock"
+                              variableName="Node2.Tx_Clock"
                               memberName="Tx_Clock" />
       <TerminalMemberVariable variableKind="signal"
-                              variableName="Node2::Tx_Data"
+                              variableName="Node2.Tx_Data"
                               memberName="Tx_Data" />
     </Terminal>
   </Terminals>

--- a/ls-bus-guide/demos/can-bus-simulation/src/App.h
+++ b/ls-bus-guide/demos/can-bus-simulation/src/App.h
@@ -55,6 +55,15 @@ void App_UpdateDiscreteStates(FmuInstance* instance);
 bool App_SetBoolean(FmuInstance* instance, fmi3ValueReference valueReference, fmi3Boolean value);
 
 /**
+ * \brief Sets the value of a float64 input variable.
+ * \note Called as part of fmi3SetFloat64.
+ * \param[in] instance The instance data of the application.
+ * \param[in] valueReference The value reference of the variable.
+ * \param[in] value The new value of the variable.
+ */
+bool App_SetFloat64(FmuInstance* instance, fmi3ValueReference valueReference, fmi3Float64 value);
+
+/**
  * \brief Sets the value of a binary input variable.
  * \note Called as part of fmi3SetBinary.
  * \param[in] instance The instance data of the application.

--- a/ls-bus-guide/demos/can-bus-simulation/src/Fmu.c
+++ b/ls-bus-guide/demos/can-bus-simulation/src/Fmu.c
@@ -241,6 +241,33 @@ FMI3_Export fmi3Status fmi3GetClock(fmi3Instance instance,
     return fmi3OK;
 }
 
+FMI3_Export fmi3Status fmi3SetFloat64(fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3Float64 values[],
+                                      size_t nValues)
+{
+    FmuInstance* fmuInstance = instance;
+
+    if (nValueReferences != nValues)
+    {
+        TerminateWithError(instance, "fmi3SetFloat64: Invalid call");
+        return fmi3Error;
+    }
+
+    for (size_t i = 0; i < nValueReferences; i++)
+    {
+        if (!App_SetFloat64(fmuInstance, valueReferences[i], values[i]))
+        {
+            TerminateWithError(instance, "fmi3SetFloat64: Invalid call with value reference %u and value %f",
+                               valueReferences[i], values[i]);
+            return fmi3Error;
+        }
+    }
+
+    return fmi3OK;
+}
+
 FMI3_Export fmi3Status fmi3SetBoolean(fmi3Instance instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
@@ -265,7 +292,7 @@ FMI3_Export fmi3Status fmi3SetBoolean(fmi3Instance instance,
         }
     }
 
-    return fmi3Error;
+    return fmi3OK;
 }
 
 FMI3_Export fmi3Status fmi3SetBinary(fmi3Instance instance,
@@ -640,15 +667,6 @@ FMI3_Export fmi3Status fmi3SetFloat32(fmi3Instance instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3Float32 values[],
-                                      size_t nValues)
-{
-    return INVALID_CALL_IF_NONZERO(nValueReferences, instance);
-}
-
-FMI3_Export fmi3Status fmi3SetFloat64(fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[],
-                                      size_t nValueReferences,
-                                      const fmi3Float64 values[],
                                       size_t nValues)
 {
     return INVALID_CALL_IF_NONZERO(nValueReferences, instance);

--- a/ls-bus-guide/demos/can-node-triggered-output/PackFmu.py
+++ b/ls-bus-guide/demos/can-node-triggered-output/PackFmu.py
@@ -9,7 +9,7 @@ FMU_PATH = Path('DemoCanNodeTriggeredOutput.fmu')
 
 # Repository to fetch the LS-BUS headers from
 LS_BUS_REPO = 'modelica/fmi-ls-bus'
-LS_BUS_REV = '4680d63c0705fbf9076f97128e913f464b442f53'
+LS_BUS_REV = '7d277c5d55b294f69d61627b1968f39d7ff9fc4d'
 LS_BUS_HEADERS = [ 'fmi3LsBus.h', 'fmi3LsBusCan.h', 'fmi3LsBusUtil.h', 'fmi3LsBusUtilCan.h' ]
 
 

--- a/ls-bus-guide/demos/can-node-triggered-output/description/modelDescription.xml
+++ b/ls-bus-guide/demos/can-node-triggered-output/description/modelDescription.xml
@@ -42,7 +42,7 @@
   <ModelVariables>
     <Float64 name="time" valueReference="1024" causality="independent" variability="continuous" description="Simulation time" />
 
-    <Binary name="CanChannel::Rx_Data"
+    <Binary name="CanChannel.Rx_Data"
         valueReference="0"
         causality="input"
         variability="discrete"
@@ -54,7 +54,7 @@
         <Start value="" />
     </Binary>
 
-    <Binary name="CanChannel::Tx_Data"
+    <Binary name="CanChannel.Tx_Data"
         valueReference="1"
         causality="output"
         variability="discrete"
@@ -64,8 +64,8 @@
         mimeType="org.fmi-standard.fmi-ls-bus.v1.can">
     </Binary>
 
-    <Clock name="CanChannel::Rx_Clock" valueReference="2" causality="input" intervalVariability="triggered" />
-    <Clock name="CanChannel::Tx_Clock" valueReference="3" causality="output" intervalVariability="triggered" />
+    <Clock name="CanChannel.Rx_Clock" valueReference="2" causality="input" intervalVariability="triggered" />
+    <Clock name="CanChannel.Tx_Clock" valueReference="3" causality="output" intervalVariability="triggered" />
 
     <Boolean name="org.fmi_standard.fmi_ls_bus.Can_BusNotifications" valueReference="128" causality="structuralParameter" variability="fixed" start="false" />
   </ModelVariables>

--- a/ls-bus-guide/demos/can-node-triggered-output/description/terminalsAndIcons.xml
+++ b/ls-bus-guide/demos/can-node-triggered-output/description/terminalsAndIcons.xml
@@ -8,16 +8,16 @@
               name="CanChannel"
               description="CAN bus terminal definition">
       <TerminalMemberVariable variableKind="signal"
-                              variableName="CanChannel::Rx_Clock"
+                              variableName="CanChannel.Rx_Clock"
                               memberName="Rx_Clock" />
       <TerminalMemberVariable variableKind="signal"
-                              variableName="CanChannel::Rx_Data"
+                              variableName="CanChannel.Rx_Data"
                               memberName="Rx_Data" />
       <TerminalMemberVariable variableKind="signal"
-                              variableName="CanChannel::Tx_Clock"
+                              variableName="CanChannel.Tx_Clock"
                               memberName="Tx_Clock" />
       <TerminalMemberVariable variableKind="signal"
-                              variableName="CanChannel::Tx_Data"
+                              variableName="CanChannel.Tx_Data"
                               memberName="Tx_Data" />
     </Terminal>
   </Terminals>

--- a/ls-bus-guide/demos/can-node-triggered-output/src/App.c
+++ b/ls-bus-guide/demos/can-node-triggered-output/src/App.c
@@ -168,6 +168,12 @@ bool App_SetBoolean(FmuInstance* instance, fmi3ValueReference valueReference, fm
 }
 
 
+bool App_SetFloat64(FmuInstance* instance, fmi3ValueReference valueReference, fmi3Float64 value)
+{
+    return false;
+}
+
+
 bool App_SetBinary(FmuInstance* instance, fmi3ValueReference valueReference, fmi3Binary value, size_t valueLength)
 {
     if (valueReference == FMU_VAR_RX_DATA)

--- a/ls-bus-guide/demos/can-node-triggered-output/src/App.h
+++ b/ls-bus-guide/demos/can-node-triggered-output/src/App.h
@@ -55,6 +55,15 @@ void App_UpdateDiscreteStates(FmuInstance* instance);
 bool App_SetBoolean(FmuInstance* instance, fmi3ValueReference valueReference, fmi3Boolean value);
 
 /**
+ * \brief Sets the value of a float64 input variable.
+ * \note Called as part of fmi3SetFloat64.
+ * \param[in] instance The instance data of the application.
+ * \param[in] valueReference The value reference of the variable.
+ * \param[in] value The new value of the variable.
+ */
+bool App_SetFloat64(FmuInstance* instance, fmi3ValueReference valueReference, fmi3Float64 value);
+
+/**
  * \brief Sets the value of a binary input variable.
  * \note Called as part of fmi3SetBinary.
  * \param[in] instance The instance data of the application.

--- a/ls-bus-guide/demos/can-node-triggered-output/src/Fmu.c
+++ b/ls-bus-guide/demos/can-node-triggered-output/src/Fmu.c
@@ -241,6 +241,33 @@ FMI3_Export fmi3Status fmi3GetClock(fmi3Instance instance,
     return fmi3OK;
 }
 
+FMI3_Export fmi3Status fmi3SetFloat64(fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3Float64 values[],
+                                      size_t nValues)
+{
+    FmuInstance* fmuInstance = instance;
+
+    if (nValueReferences != nValues)
+    {
+        TerminateWithError(instance, "fmi3SetFloat64: Invalid call");
+        return fmi3Error;
+    }
+
+    for (size_t i = 0; i < nValueReferences; i++)
+    {
+        if (!App_SetFloat64(fmuInstance, valueReferences[i], values[i]))
+        {
+            TerminateWithError(instance, "fmi3SetFloat64: Invalid call with value reference %u and value %f",
+                               valueReferences[i], values[i]);
+            return fmi3Error;
+        }
+    }
+
+    return fmi3OK;
+}
+
 FMI3_Export fmi3Status fmi3SetBoolean(fmi3Instance instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
@@ -265,7 +292,7 @@ FMI3_Export fmi3Status fmi3SetBoolean(fmi3Instance instance,
         }
     }
 
-    return fmi3Error;
+    return fmi3OK;
 }
 
 FMI3_Export fmi3Status fmi3SetBinary(fmi3Instance instance,
@@ -640,15 +667,6 @@ FMI3_Export fmi3Status fmi3SetFloat32(fmi3Instance instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3Float32 values[],
-                                      size_t nValues)
-{
-    return INVALID_CALL_IF_NONZERO(nValueReferences, instance);
-}
-
-FMI3_Export fmi3Status fmi3SetFloat64(fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[],
-                                      size_t nValueReferences,
-                                      const fmi3Float64 values[],
                                       size_t nValues)
 {
     return INVALID_CALL_IF_NONZERO(nValueReferences, instance);


### PR DESCRIPTION
Bus Simulation:
- Add full support for arbitration
- Improve clock interval handling
- Implement basic error injection
- Fix bug where frames are pushed into the wrong queue

All FMUs:
- Rename terminal member variables
- Update to support current LS-BUS (commit 7d277c5d55b294f69d61627b1968f39d7ff9fc4d)