### PR TITLE
Fix Bus Simulation example FMU (empty frames)

### DIFF
--- a/ls-bus-guide/demos/can-bus-simulation/description/modelDescription.xml
+++ b/ls-bus-guide/demos/can-bus-simulation/description/modelDescription.xml
@@ -51,7 +51,6 @@
         maxSize="2048"
         clocks="2"
         mimeType="application/org.fmi-standard.fmi-ls-bus.can; version=&quot;1.0.0-beta.1&quot;">
-        <Dimension start="1" />
         <Start value="" />
     </Binary>
 
@@ -76,7 +75,6 @@
             maxSize="2048"
             clocks="6"
             mimeType="application/org.fmi-standard.fmi-ls-bus.can; version=&quot;1.0.0-beta.1&quot;">
-      <Dimension start="1" />
       <Start value="" />
     </Binary>
 

--- a/ls-bus-guide/demos/can-bus-simulation/src/App.c
+++ b/ls-bus-guide/demos/can-bus-simulation/src/App.c
@@ -125,6 +125,8 @@ static bool FrameQueue_Enqueue(FrameQueue* queue, const fmi3LsBusCanOperationCan
     queue->Entries[queue->WritePos].Rtr = transmitOp->rtr;
     queue->Entries[queue->WritePos].DataLength = transmitOp->dataLength;
 
+    memcpy(queue->Entries[queue->WritePos].Data, transmitOp->data, transmitOp->dataLength);
+
     queue->WritePos = FRAME_QUEUE_INCREMENT(queue->WritePos, FrameQueueSize);
 
     return true;

--- a/ls-bus-guide/demos/can-bus-simulation/src/App.c
+++ b/ls-bus-guide/demos/can-bus-simulation/src/App.c
@@ -254,7 +254,7 @@ void App_EvaluateDiscreteStates(FmuInstance* instance)
                     if (configOp->parameterType == FMI3_LS_BUS_CAN_CONFIG_PARAM_TYPE_CAN_BAUDRATE)
                     {
                         LogFmuMessage(instance, fmi3OK, "Info",
-                                      "Node %u configured baud rate %u", i, configOp->baudrate);
+                                      "Node %u configured baud rate %u", i + 1, configOp->baudrate);
                         instance->App->Nodes[i].BaudRate = configOp->baudrate;
                     }
                     else if (configOp->parameterType == FMI3_LS_BUS_CAN_CONFIG_PARAM_TYPE_ARBITRATION_LOST_BEHAVIOR)

--- a/ls-bus-guide/demos/can-bus-simulation/src/Fmu.c
+++ b/ls-bus-guide/demos/can-bus-simulation/src/Fmu.c
@@ -420,6 +420,10 @@ FMI3_Export fmi3Status fmi3GetIntervalFraction(fmi3Instance instance,
                                valueReferences[i]);
             return fmi3Error;
         }
+
+        if (resolutions[i] <= 0) {
+            qualifiers[i] = fmi3IntervalNotYetKnown;
+        }
     }
 
     return fmi3OK;

--- a/ls-bus-guide/demos/can-bus-simulation/src/Fmu.c
+++ b/ls-bus-guide/demos/can-bus-simulation/src/Fmu.c
@@ -392,7 +392,12 @@ FMI3_Export fmi3Status fmi3GetIntervalDecimal(fmi3Instance instance,
                                valueReferences[i]);
             return fmi3Error;
         }
-        intervals[i] = (fmi3Float64)counter / (fmi3Float64)resolution;
+
+        if (resolution <= 0) {
+            qualifiers[i] = fmi3IntervalNotYetKnown;
+        } else {
+            intervals[i] = (fmi3Float64)counter / (fmi3Float64)resolution;
+        }
     }
 
     return fmi3OK;


### PR DESCRIPTION
This PR fixes the empty frames sent by the bus simulation FMU.
plus some minor things like log messages